### PR TITLE
adding self as the thread argument for confluentcallbacks __init__.

### DIFF
--- a/faust/transport/drivers/confluent.py
+++ b/faust/transport/drivers/confluent.py
@@ -161,7 +161,7 @@ class ConfluentConsumerThread(ConsumerThread, BrokerCredentialsMixin):
     topics = []
 
     def __init__(self, *args: Any, **kwargs: Any):
-        self.confluentcallbacks = ConfluentCallbacks()
+        self.confluentcallbacks = ConfluentCallbacks(self)
         super().__init__(*args, **kwargs)
 
     async def on_start(self) -> None:


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
